### PR TITLE
Share tree geometry and materials across trees

### DIFF
--- a/src/tree.ls
+++ b/src/tree.ls
@@ -1,43 +1,67 @@
 # TODO: create global meshes for each type of tree, select from meshes
 # since creating new meshes for each tree consumes too many resources
+
+
+tree1-generated-materials = false
+tree1-trunk-geometry = 0
+tree1-trunk-material = 0
+tree1-leaf-geometry1 = 0
+tree1-leaf-geometry2 = 0
+tree1-leaf-geometry3 = 0
+tree1-leaf-material = 0
+
+
 generate-pine-tree = ->
-  tree = new THREE.Object3D!
+    trunk-height = 8
+    trunk-top-radius = 10
+    trunk-bot-radius = 15
+    leaf-height = 20
+    leaf-overlap = 10
+    leaf-radius = 25
+    leaf-radius-shrink = 3
 
-  trunk-height = 8
-  trunk-top-radius = 10
-  trunk-bot-radius = 15
-  leaf-height = 20
-  leaf-overlap = 10
-  leaf-radius = 25
-  leaf-radius-shrink = 3
+    if tree1-generated-materials == false
+        tree1-generated-materials := true
+        tree1-trunk-geometry := new THREE.CylinderGeometry trunk-top-radius,
+            trunk-bot-radius,
+            trunk-height,
+            5 # segments
+        tree1-trunk-material := new THREE.MeshPhongMaterial color: 0x8b4513
 
-  trunk-geo = new THREE.CylinderGeometry \
-    trunk-top-radius,
-    trunk-bot-radius,
-    trunk-height,
-    5 # segments
+        tree1-leaf-geometry1 := new THREE.ConeGeometry leaf-radius - leaf-radius-shrink,
+            leaf-height,
+            5 # segments
+        tree1-leaf-geometry2 := new THREE.ConeGeometry leaf-radius - leaf-radius-shrink * 2,
+            leaf-height,
+            5 # segments
+        tree1-leaf-geometry3 := new THREE.ConeGeometry leaf-radius - leaf-radius-shrink * 3,
+            leaf-height,
+            5 # segments
+        tree1-leaf-material := new THREE.MeshPhongMaterial color: 0x556b2f
 
-  tree.add ((new THREE.Mesh \
-    trunk-geo,
-    (new THREE.MeshPhongMaterial color: 0x8b4513))
-    ..position.y = trunk-height / 2)
 
+    tree = new THREE.Object3D!
 
-  for i from 0 til 3
-    leaf-geo = new THREE.ConeGeometry \
-      leaf-radius - leaf-radius-shrink * i,
-      leaf-height,
-      5 # segments
-    tree.add ((new THREE.Mesh \
-      leaf-geo,
-      (new THREE.MeshPhongMaterial color: 0x556b2f))
-      ..position.y = trunk-height + leaf-height / 2 + (leaf-height - leaf-overlap) * i
-      ..rotation.y = 2 * Math.PI * Math.random!)
+    tree.add ((new THREE.Mesh tree1-trunk-geometry,
+        (tree1-trunk-material))
+        ..position.y = trunk-height / 2)
+    tree.add (( new THREE.Mesh tree1-leaf-geometry1,
+        (tree1-leaf-material))
+        ..position.y = trunk-height + leaf-height / 2 + (leaf-height - leaf-overlap)
+        ..rotation.y = 2 * Math.PI * Math.random!)
+    tree.add (( new THREE.Mesh tree1-leaf-geometry2,
+        (tree1-leaf-material))
+        ..position.y = trunk-height + leaf-height / 2 + (leaf-height - leaf-overlap) * 1
+        ..rotation.y = 2 * Math.PI * Math.random!)
+    tree.add (( new THREE.Mesh tree1-leaf-geometry3,
+        (tree1-leaf-material))
+        ..position.y = trunk-height + leaf-height / 2 + (leaf-height - leaf-overlap) * 2
+        ..rotation.y = 2 * Math.PI * Math.random!)
 
-  tree
+    tree
 
 export pine = "pine"
 
 export generate-tree = (type) ->
-  if type == pine
-    generate-pine-tree!
+    if type == pine
+        generate-pine-tree!


### PR DESCRIPTION
Made questionably ethical improvements allowing the sharing of geometry and materials between trees.

Refactoring code to allow multiple types of trees should be relatively straightforward.